### PR TITLE
Feature/mono repo

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -57,7 +57,7 @@ on:
         description: 'Path to SLNX file'
         required: true
         default: ./src
-      sln:
+      solutionFileName:
         type: string
         description: 'The SLNX full name. eg: DEPLOY.PROJECT.API.slnx'
         required: true
@@ -238,7 +238,7 @@ jobs:
             /d:sonar.exclusions="${{ inputs.sonarExclusions || ' '}}"
           dotnet restore ${{ inputs.projectBaseDir }}/${{ inputs.mainProject }}/${{ inputs.mainProject }}.csproj
           dotnet build ${{ inputs.projectBaseDir }}/${{ inputs.mainProject }}/${{ inputs.mainProject }}.csproj --no-incremental
-          dotnet-coverage collect 'dotnet test ${{ inputs.projectBaseDir }}' --output-format xml --output 'coverage.xml'
+          dotnet-coverage collect 'dotnet test ${{ inputs.projectBaseDir }}/${{ inputs.solutionFileName }}' --output-format xml --output 'coverage.xml'
           dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
 
       - name: ReportGenerator
@@ -275,7 +275,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --sarif-file-output=snyk.sarif --file=${{ inputs.projectBaseDir }}/${{ inputs.sln }}
+          args: --sarif-file-output=snyk.sarif --file=${{ inputs.projectBaseDir }}/${{ inputs.solutionFileName }}
 
       - name: 🍵 Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/sandbox-api.yml
+++ b/.github/workflows/sandbox-api.yml
@@ -62,7 +62,7 @@ on:
         description: 'Path to SLNX file'
         required: true
         default: ./src
-      sln:
+      solutionFileName:
         type: string
         description: 'The SLNX full name. eg: DEPLOY.PROJECT.API.slnx'
         required: true
@@ -321,7 +321,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --sarif-file-output=snyk.sarif --file=${{ inputs.projectBaseDir }}/${{ inputs.sln }}
+          args: --sarif-file-output=snyk.sarif --file=${{ inputs.projectBaseDir }}/${{ inputs.solutionFileName }}
 
       - name: 🍵 Upload result to GitHub Code Scanning
         if: ${{ inputs.git-leaks }}


### PR DESCRIPTION
This pull request updates the input parameter naming and its usage in two GitHub Actions workflow files: `.github/workflows/pr-check.yml` and `.github/workflows/sandbox-api.yml`. The changes aim to improve clarity and consistency by renaming the `sln` input to `solutionFileName` and updating all relevant references.

### Input Parameter Renaming:

* `.github/workflows/pr-check.yml`:
  - Renamed the `sln` input to `solutionFileName` in the workflow inputs section.
  - Updated the `dotnet-coverage` command to use the renamed `solutionFileName` input instead of `sln`.
  - Updated the Snyk command to use `solutionFileName` in place of `sln`.

* `.github/workflows/sandbox-api.yml`:
  - Renamed the `sln` input to `solutionFileName` in the workflow inputs section.
  - Updated the Snyk command to use `solutionFileName` instead of `sln`.